### PR TITLE
clean up the quickstart in the readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ notifications:
 branches:
   only: master
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install gcc gfortran libav-tools -y ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install gcc gfortran -y ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:mc3man/trusty-media && sudo apt-get update && sudo apt-get install -y ffmpeg && ffmpeg -version ; fi
   - export PYTHON=""
   - julia -e 'Pkg.add("Conda"); using Conda; Conda.add("numpy")'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
   only: master
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install gcc gfortran -y ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:mc3man/trusty-media && sudo apt-get update && sudo apt-get install -y ffmpeg && ffmpeg -version ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:mc3man/trusty-media && sudo apt-get update && sudo apt-get install -y ffmpeg && ffmpeg -version ; fi
   - export PYTHON=""
   - julia -e 'Pkg.add("Conda"); using Conda; Conda.add("numpy")'
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,29 +2,40 @@
 
 [![Build Status](https://travis-ci.org/rdeits/DynamicWalking2018.jl.svg?branch=master)](https://travis-ci.org/rdeits/DynamicWalking2018.jl)
 
-To follow along with the presentation, take a look at the Jupyter notebooks in the `notebooks` folder. To get started with Julia, check out the [getting started notebook](https://github.com/rdeits/DynamicWalking2018.jl/blob/master/notebooks/1.%20Introducing%20Julia.ipynb).
+To follow along with the presentation, take a look at the Jupyter notebooks in the `notebooks` folder.
 
 ## Quickstart
 
-If you want to run these demo notebooks yourself, you'll need to install:
-
-* Julia
-* IJulia (for using Julia in Jupyter notebooks)
-* This package
-
 ### Installing Julia
 
-Download a Julia binary from https://julialang.org/downloads/ and follow the [installation instructions](https://julialang.org/downloads/platform.html#windows).
+If you just want to try out Julia itself, all you need to do is download a Julia binary from https://julialang.org/downloads/ and follow the [installation instructions](https://julialang.org/downloads/platform.html#windows).
 
-### Installing IJulia
+Now you're ready to write Julia code and install other packages.
 
-In Julia, do:
+### Using Julia In Jupyter Notebooks
+
+[Jupyter notebooks](http://jupyter.org/) are a great way to write interactive, descriptive code and to integrate code with data, graphs, and other results. Julia works great with Jupyter, and we'll run this tutorial inside a collection of notebooks.
+
+To use Julia inside a Jupyter notebook, you will also need to install the `IJulia` package.
+
+Start Julia, then run:
 
 ```julia
 Pkg.add("IJulia")
 ```
 
-### Installing this tutorial package
+To start up Jupyter, you can run (in Julia):
+
+```julia
+using IJulia
+notebook(dir=pwd())
+```
+
+or if you're already a Jupyter user, you can simply run `jupyter notebook` as usual.
+
+### Installing this Entire Tutorial
+
+If you want all of the packages necessary to run this entire tutorial, then you just need to install this tutorial as another Julia package.
 
 In Julia, do:
 
@@ -32,7 +43,7 @@ In Julia, do:
 Pkg.clone("https://github.com/rdeits/DynamicWalking2018.jl")
 ```
 
-Note that this will take a few minutes. We're demonstrating a lot of different Julia packages here, so this tutorial has a lot of dependencies, which may take a bit of time to download. These dependencies will all be downloaded for you automatically.
+Note that this will take a few minutes. We're demonstrating a lot of different Julia packages here, so this tutorial has a lot of dependencies, which may take a bit of time to download.
 
 For example, you'll be getting:
 
@@ -56,6 +67,6 @@ notebook(dir=Pkg.dir("DynamicWalking2018", "notebooks"))
 
 or simply run `jupyter notebook` from the command line, if you already have it installed.
 
-### Notes on Startup
+## Notes on Startup
 
 The first time you run a given function, Julia compiles native code for that particular function and its input types. Try running functions a few times to get a sense for how long they actually take once they've been compiled.


### PR DESCRIPTION
Try to clarify that users don't have to install the entire tutorial
package if all they want to do is play around in Julia.